### PR TITLE
Impl `start_fastn` function and minor refactor.

### DIFF
--- a/FTNet/src/config/dotftnet/init_if_required.rs
+++ b/FTNet/src/config/dotftnet/init_if_required.rs
@@ -1,23 +1,10 @@
 /// this function is called on startup, and initializes the FTNet directory if it doesn't exist
 #[tracing::instrument(skip(client_pools))]
 pub async fn init_if_required(
-    dir: Option<String>,
+    dir: &std::path::Path,
     client_pools: ftnet::http::client::ConnectionPools,
 ) -> eyre::Result<std::path::PathBuf> {
     use eyre::WrapErr;
-
-    let dir = match dir {
-        Some(dir) => dir.into(),
-        // https://docs.rs/directories/6.0.0/directories/struct.ProjectDirs.html#method.data_dir
-        None => match directories::ProjectDirs::from("com", "FifthTry", "FTNet") {
-            Some(dir) => dir.data_dir().to_path_buf(),
-            None => {
-                return Err(eyre::anyhow!(
-                    "dotFTNet init failed: can not find data dir when dir is not provided"
-                ));
-            }
-        },
-    };
 
     if !dir.exists() {
         // TODO: create the directory in an incomplete state, e.g., in the same parent,
@@ -39,5 +26,5 @@ pub async fn init_if_required(
         ftnet::Identity::create(&identities, client_pools).await?;
     }
 
-    Ok(dir)
+    Ok(dir.to_path_buf())
 }

--- a/FTNet/src/config/read.rs
+++ b/FTNet/src/config/read.rs
@@ -8,7 +8,7 @@ impl ftnet::Config {
     }
 
     pub async fn read(
-        dir: Option<String>,
+        dir: &std::path::Path,
         client_pools: ftnet::http::client::ConnectionPools,
     ) -> eyre::Result<Self> {
         let dir = ftnet::config::dotftnet::init_if_required(dir, client_pools)

--- a/FTNet/src/lib.rs
+++ b/FTNet/src/lib.rs
@@ -7,6 +7,7 @@
 // Only the binary is using the following crates:
 use fastn_observer as _;
 use tracing_subscriber as _;
+use directories as _;
 
 extern crate self as ftnet;
 

--- a/FTNet/src/main.rs
+++ b/FTNet/src/main.rs
@@ -12,7 +12,22 @@ async fn main() -> eyre::Result<()> {
             foreground,
             data_dir,
             control_port,
-        } => ftnet::start(foreground, data_dir, control_port).await,
+        } => {
+            let data_dir = match data_dir {
+                Some(dir) => dir.into(),
+                // https://docs.rs/directories/6.0.0/directories/struct.ProjectDirs.html#method.data_dir
+                None => match directories::ProjectDirs::from("com", "FifthTry", "FTNet") {
+                    Some(dir) => dir.data_dir().to_path_buf(),
+                    None => {
+                        return Err(eyre::anyhow!(
+                            "dotFTNet init failed: can not find data dir when dir is not provided"
+                        ));
+                    }
+                },
+            };
+
+            ftnet::start(foreground, data_dir, control_port).await
+        }
         ftnet::Command::TcpProxy { id, port } => {
             println!("Proxying TCP server to remote FTNet service with id: {id}, port: {port}");
             Ok(())

--- a/FTNet/src/start.rs
+++ b/FTNet/src/start.rs
@@ -6,13 +6,13 @@
 /// identities folder, and set-up http device driver for each of them.
 ///
 /// it also has to start the device "drivers" for every device in the <identities>/devices folder.
-pub async fn start(_fg: bool, dir: Option<String>, control_port: u16) -> eyre::Result<()> {
+pub async fn start(_fg: bool, data_dir: std::path::PathBuf, control_port: u16) -> eyre::Result<()> {
     use eyre::WrapErr;
 
     let client_pools = ftnet::http::client::ConnectionPools::default();
     let peer_connections = ftnet::identity::PeerConnections::default();
 
-    let config = ftnet::Config::read(dir, client_pools.clone())
+    let config = ftnet::Config::read(&data_dir, client_pools.clone())
         .await
         .wrap_err_with(|| "failed to run config")?;
 
@@ -46,10 +46,11 @@ pub async fn start(_fg: bool, dir: Option<String>, control_port: u16) -> eyre::R
         let graceful_shutdown_rx = graceful_shutdown_rx.clone();
         let id_map = Arc::clone(&id_map);
         let peer_connections = Arc::clone(&peer_connections);
+        let data_dir = data_dir.clone();
         tokio::spawn(async move {
             let public_key = identity.public_key;
             if let Err(e) = identity
-                .run(graceful_shutdown_rx, id_map, peer_connections)
+                .run(graceful_shutdown_rx, id_map, peer_connections, &data_dir)
                 .await
             {
                 eprintln!("failed to run identity: {public_key}: {e:?}");


### PR DESCRIPTION
- Impl `start_fastn`: It runs `fastn serve` in your identity folder (`<data-dir>/identities/<identity>/package/`) and returns the port on which the server is listening.
- Resolve `data_dir` early in `main.rs` this lets us avoid checking for `Option<String>` later in our code and freely use `std::path::Path`.